### PR TITLE
update pages and links for roadmap location #17

### DIFF
--- a/src/_data/navigation.json
+++ b/src/_data/navigation.json
@@ -15,7 +15,7 @@
     },
     {
       "text": "Roadmap",
-      "url": "/products/roadmap/"
+      "url": "/roadmap/"
     },
     {
       "text": "Labs",

--- a/src/products/roadmap.md
+++ b/src/products/roadmap.md
@@ -1,5 +1,0 @@
----
-layout: "layouts/products.liquid"
-title: Roadmap (coming soon)
-meta_description: ""
----


### PR DESCRIPTION
Note, at cloudflare I've made a redirect for oa.works/roadmap (which you can test).

I've done this only on live. Ideally we'd make one on dev too, but this is also a problem that likely goes away if we just wait for cloudflare pages to mature a bit.

Closes https://github.com/OAButton/internal-planning/issues/17