### PR TITLE
add anchor to fsp section

### DIFF
--- a/src/policies/governance.md
+++ b/src/policies/governance.md
@@ -20,7 +20,7 @@ Find out more:
 
 [Code for Science & Society](https://www.codeforsociety.org/) (CS&S) is a 501(c)(3) US public charity focusing on the social and organizational infrastructure required for data to improve lives. They fiscally sponsor projects to empower communities to work together and build innovative technology for the public good. CS&S has been sponsoring [an incredible set of projects](https://www.codeforsociety.org/fsp/projects) since 2017, and they specialize in supporting small open source projects in scholarly communications.
 
-The board of CS&S takes on the legal and fiduciary obligations of a nonprofit board of directors for their fiscally sponsored projects. However, OA.Works’ remains responsible for strategic decisions, with CS&S offering guidance when requested, and our Advisory Committee can choose to set up an independent non-profit or move to another fiscal sponsor.
+The board of CS&S takes on the legal and fiduciary obligations of a nonprofit board of directors for their fiscally sponsored projects. However, OA.Works’ remains responsible for strategic decisions, with CS&S offering guidance when requested, and our Advisory Committee can choose to set up an independent non-profit or move to another fiscal sponsor.<a id=fsp></a>
 
 ## About fiscal sponsorship
 


### PR DESCRIPTION
A couple of times in the past few days the need for a direct link to the "About fiscal sponsorship" has come up.

I've added an anchor to support that. I've added it to the paragraph before rather than the header as that keeps the header in view when the link is clicked (at least on desktop, where I tested). This feels like a reasonable approach for this "one-off", but if we want to do more or you know a quick fix we should probably improve this.