### PR TITLE
Support codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "image": "mcr.microsoft.com/devcontainers/universal:2",
+    "features": {},
+    "postCreateCommand": "npm install @11ty/eleventy && npm run serve:dev"
+ }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ Prerequisites:
 
 5. Direct your web browser to `http://localhost:8080/`.
 
+If running locally isn't your thing, try:
+
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=support-codespaces&repo=321735364&machine=basicLinux32gb&devcontainer_path=.devcontainer%2Fdevcontainer.json&location=WestEurope)
+
 ## Setting environment variables
 
 When cloning this repository locally, you will need to create a `.env` file that will contain:


### PR DESCRIPTION
In working on the quick addition for https://github.com/oaworks/oa-works/pull/173 I wanted a quick and easy way to run the site "locally" so I ported what I'd done on oa-report here (as running locally often fails on my machine). This is tested and works.