### PR TITLE
Update homepage partners copy

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@ meta_description: "We're a non-profit project building free and open source tool
       <figure class="col col--1of4 flex-end flex-col" data-sal="slide-up" data-sal-delay="50">
         <header>
           <p class="label label--secondary line-thru">
-            <small class="line-thru__inner bg-white label">Our partner for</small>
+            <small class="line-thru__inner bg-white label">What our community is saying</small>
           </p>
           <h3> {{ t.product }}</h3>
         </header>


### PR DESCRIPTION
The homepage copy of "Our partner for" no long works as we've added testimonials from folks who aren't partners. Suggested update.